### PR TITLE
Catch empty summary with try/except

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -53,7 +53,10 @@ class YouTubeAgent(Agent.Movies):
 			thumb = 'https://%s' % (json_obj['video']['thumbnail_for_watch'].split('//')[-1])
 			metadata.posters[thumb] = Proxy.Preview(HTTP.Request(thumb).content, sort_order=1)
 
-			metadata.summary = json_obj['video_main_content']['contents'][0]['description']['runs'][0]['text']
+			try:
+				metadata.summary = json_obj['video_main_content']['contents'][0]['description']['runs'][0]['text']
+			except IndexError:
+				Log('No Summary for: %s' % metadata.id)
 
 			date = Datetime.ParseDate(json_obj['video_main_content']['contents'][0]['date_text']['runs'][0]['text'].split('on ')[-1])
 			metadata.originally_available_at = date.date()


### PR DESCRIPTION
In cases where there is no summary this will break.

Test Video: https://www.youtube.com/watch?v=Gmyvr9jydpU
Error Message:
2017-06-04 23:58:45,977 (-c35c4c0) :  CRITICAL (agentkit:1078) - Exception in the update function of agent named 'YouTube', called with guid 'com.plexapp.agents.youtube://Gmyvr9jydpU?lang=xn' (most recent call last):
  File "/volume1/@appstore/Plex Media Server/Resources/Plug-ins-8088811b8/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1076, in _update
    agent.update(obj, media, lang, **kwargs)
  File "/volume1/Plex/Library/Application Support/Plex Media Server/Plug-ins/YouTube-Agent.bundle/Contents/Code/__init__.py", line 55, in update
    metadata.summary = json_obj['video_main_content']['contents'][0]['description']['runs'][0]['text']
  File "/volume1/@appstore/Plex Media Server/Resources/Plug-ins-8088811b8/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/code/sandbox.py", line 108, in <lambda>
    _getitem_           = lambda x, y: x.__getitem__(y),
IndexError: list index out of range